### PR TITLE
Remove version constraints for com.ibm.icu package imports

### DIFF
--- a/org.eclipse.emf.validation.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.emf.validation.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Export-Package: org.eclipse.emf.validation.ui.internal;x-internal:=true,
  org.eclipse.emf.validation.ui.internal.l10n;x-internal:=true,
  org.eclipse.emf.validation.ui.internal.preferences;x-internal:=true,
  org.eclipse.emf.validation.ui.preferences
-Import-Package: com.ibm.icu.text;version="4.0.0"
+Import-Package: com.ibm.icu.text
 Require-Bundle: org.eclipse.emf.validation;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.emf.validation/META-INF/MANIFEST.MF
+++ b/org.eclipse.emf.validation/META-INF/MANIFEST.MF
@@ -22,9 +22,9 @@ Export-Package: org.eclipse.emf.validation,
  org.eclipse.emf.validation.service,
  org.eclipse.emf.validation.util,
  org.eclipse.emf.validation.xml
-Import-Package: com.ibm.icu.text;version="4.0.0",
- com.ibm.icu.lang;version="4.0.0",
- com.ibm.icu.util;version="4.0.0"
+Import-Package: com.ibm.icu.text,
+ com.ibm.icu.lang,
+ com.ibm.icu.util
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="[2.3.0,3.0.0)";visibility:=reexport,
  org.eclipse.emf.edit;bundle-version="[2.3.0,3.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.2.0,4.0.0)",


### PR DESCRIPTION
Follow-up for: https://github.com/eclipse-platform/eclipse.platform.releng/issues/69

Essentially the problem is:

`Root cause is that [..] bundles expect versioned com.ibm.icu.text package to exist in the installation, but 4.25 SDK brings only plain maven artifact without proper package metadata.`

See also:

- https://git.eclipse.org/r/c/webtools-common/webtools.common/+/194676
- https://git.eclipse.org/r/c/sourceediting/webtools.sourceediting/+/194679
- https://github.com/eclipse/gef-classic/pull/91